### PR TITLE
Query multiline support and use of LIMIT OFFSET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 /db
 /public
+/nbproject

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -139,14 +139,14 @@ class Datatables {
 
     protected function setcolumns($query)
     {
-        $query = preg_replace("/\((?:[^()]+|(?R))*+\)/i", "", $query);
-        preg_match_all("/SELECT([\s\S]*?)((\s*)\bFROM\b(?![\s\S]*\)))([\s\S]*?)/i", $query, $columns);
+        $query = preg_replace("/\((?:[^()]+|(?R))*+\)/is", "", $query);
+        preg_match_all("/SELECT([\s\S]*?)((\s*)\bFROM\b(?![\s\S]*\)))([\s\S]*?)/is", $query, $columns);
 
         $columns = $this->explode(",", $columns[1][0]);
 
         // gets alias of the table -> 'table.column as col' or 'table.column col' to 'col'
-        $regex[] = "/(.*)\s+as\s+(.*)/i";
-        $regex[] = "/.+(\([^()]+\))?\s+(.+)/i";
+        $regex[] = "/(.*)\s+as\s+(.*)/is";
+        $regex[] = "/.+(\([^()]+\))?\s+(.+)/is";
         // wipe unwanted characters => '`" and space
         $regex[] = '/[\s"\'`]+/';
         // if there is no alias, return column name -> table.column to column
@@ -175,7 +175,7 @@ class Datatables {
             return null;
         }
 
-        return " LIMIT $skip, $take ";
+        return " LIMIT $take OFFSET $skip";
     }
 
     protected function orderby()


### PR DESCRIPTION
I added the 's' modifier to the regexp to support multiline, as an example:
```
    select unit.name,
	acc_hours,
        case when next_serv - acc_hours is null then 0
        else next_serv - acc_hours end as service,
       last_serv + serv_duration  - acc_hours as remaining
       from unit_service, unit 
     #....
```
The service column ended up as '`whennext_servacc_hoursisnullthen0service`' and would break the query.

The second modification (LIMIT OFFSET) is to add posgresql support.