### PR TITLE
New method to add new column

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A simple ajax example:
 This is the list of available public methods.
 
 * query ( $query : string ) `(required)`
+* add ($newColumn:string, Closure:object ) `(optional)`
 * edit ($column:string, Closure:object ) `(optional)`
 * get ($value:string ) `(optional - for dev purpose)`
 * hide ($column:mixed ) `(optional)`
@@ -98,6 +99,11 @@ This is the list of available public methods.
         }
 
         return 'you are not authorized to view this column';
+    });
+
+    $dt->add('action', function($data){
+        // return an edit link in new column action
+        return "<a href='user.php?id=" . $data['id'] . "'>edit</a>";
     });
 
     echo $dt->generate();

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -11,6 +11,7 @@ class Datatables {
     protected $recordstotal;
     protected $recordsfiltered;
     protected $columns;
+    protected $add;
     protected $edit;
     protected $hide;
     protected $sql;
@@ -229,6 +230,15 @@ class Datatables {
 
         foreach ($this->data as $key => $row)
         {
+            // new columns..
+            if (count($this->add) > 0)
+            {
+                foreach ($this->add as $new_column => $closure)
+                {
+                    $row[ $new_column ] = $closure($row);
+                }
+            }
+
             // editing columns..
             if (count($this->edit) > 0)
             {
@@ -250,6 +260,13 @@ class Datatables {
         $response['data'] = $formatted_data;
 
         return $this->response($response, $json);
+    }
+
+    public function add($newColumn, $closure)
+    {
+        $this->add[ $newColumn ] =  $closure;
+
+        return $this;
     }
 
     public function edit($column, $closure)

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -244,7 +244,9 @@ class Datatables {
             {
                 foreach ($this->edit as $edit_column => $closure)
                 {
-                    $row[ $edit_column ] = $closure($row);
+                    if (isset($row[ $edit_column ])) {
+                        $row[ $edit_column ] = $closure($row);
+                    }
                 }
             }
 


### PR DESCRIPTION
I added the functionnality to be able to add a new column.
For example, in case user would like to add an action column to edit, delete or whatever else without having to do it in javascript.

Example :

in javascript, add new column (in datatable init options)
```
columns: [
    { data: "action", orderable: false, searchable: false }
]
```

in php, use new method add
```
$dt->add('action', function($data){
    // return an edit link in new column action
    return "<a href='user.php?id=" . $data['id'] . "'>edit</a>";
});
```