### PR TITLE
Trigger the search

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -24,6 +24,13 @@ class Column
     public $hidden = false;
 
     /**
+     * Column seachable
+     *
+     * @var bool
+     */
+    public $triggerSearch = false;
+
+    /**
      * Callback function
      *
      * @var \Closure
@@ -77,6 +84,13 @@ class Column
         $this->hidden = true;
     }
 
+    /**
+     * Set seachable of the column.
+     */
+    public function triggerSearch(): void
+    {
+        $this->triggerSearch = true;
+    }
 
     /**
      * @return bool
@@ -115,6 +129,6 @@ class Column
      */
     public function searchValue(): string
     {
-        return $this->attr['search']['value'];
+        return $this->attr['search']['value'] ?? '';
     }
 }

--- a/src/Column.php
+++ b/src/Column.php
@@ -28,7 +28,7 @@ class Column
      *
      * @var bool
      */
-    public $triggerSearch = false;
+    public $forceSearch = false;
 
     /**
      * Callback function
@@ -79,17 +79,10 @@ class Column
     /**
      * Set visibility of the column.
      */
-    public function hide(): void
+    public function hide($searchable = false): void
     {
         $this->hidden = true;
-    }
-
-    /**
-     * Set seachable of the column.
-     */
-    public function triggerSearch(): void
-    {
-        $this->triggerSearch = true;
+        $this->forceSearch = $searchable;
     }
 
     /**

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -157,6 +157,23 @@ class Datatables
     }
 
     /**
+     * @param array $columns
+     * @return Datatables
+     */
+    public function triggerSearch(...$columns): Datatables
+    {
+        foreach ($columns as $column) {
+            if (\is_array($column)) {
+                $this->triggerSearch(...$column);
+            } else {
+                $this->columns->getByName($column)->triggerSearch();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $query
      * @return Datatables
      */

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -140,19 +140,12 @@ class Datatables
     }
 
     /**
-     * @param array $columns
+     * @param string $column
      * @return Datatables
      */
-    public function hide($searchable = false, ...$columns): Datatables
+    public function hide(string $column, $searchable = false): Datatables
     {
-        foreach ($columns as $column) {
-            if (\is_array($column)) {
-                $this->hide($searchable, ...$column);
-            } else {
-                $this->columns->getByName($column)->hide($searchable);
-            }
-        }
-
+        $this->columns->getByName($column)->hide($searchable);
         return $this;
     }
 

--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -143,30 +143,13 @@ class Datatables
      * @param array $columns
      * @return Datatables
      */
-    public function hide(...$columns): Datatables
+    public function hide($searchable = false, ...$columns): Datatables
     {
         foreach ($columns as $column) {
             if (\is_array($column)) {
-                $this->hide(...$column);
+                $this->hide($searchable, ...$column);
             } else {
-                $this->columns->getByName($column)->hide();
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param array $columns
-     * @return Datatables
-     */
-    public function triggerSearch(...$columns): Datatables
-    {
-        foreach ($columns as $column) {
-            if (\is_array($column)) {
-                $this->triggerSearch(...$column);
-            } else {
-                $this->columns->getByName($column)->triggerSearch();
+                $this->columns->getByName($column)->hide($searchable);
             }
         }
 

--- a/src/Iterators/GlobalSearchableColumns.php
+++ b/src/Iterators/GlobalSearchableColumns.php
@@ -17,6 +17,6 @@ class GlobalSearchableColumns extends FilterIterator
      */
     public function accept(): bool
     {
-        return !$this->current()->hidden && $this->current()->isSearchable();
+        return ($this->current()->triggerSearch || (!$this->current()->hidden && $this->current()->isSearchable()));
     }
 }

--- a/src/Iterators/GlobalSearchableColumns.php
+++ b/src/Iterators/GlobalSearchableColumns.php
@@ -17,6 +17,6 @@ class GlobalSearchableColumns extends FilterIterator
      */
     public function accept(): bool
     {
-        return ($this->current()->triggerSearch || (!$this->current()->hidden && $this->current()->isSearchable()));
+        return ($this->current()->forceSearch || (!$this->current()->hidden && $this->current()->isSearchable()));
     }
 }


### PR DESCRIPTION
Use for searching in hidden field.
```php
$dt->edit('username', function($data){
    return '<a href="user/' . $data['id'] . '">
        ' . (empty($data['nickname']) ? $data['username'] : $data['nickname']) . '
    </a>';
});
$dt->hide('nickname')->triggerSearch('nickname');
```
---
Before that, I tried adding search to the query:
```php
$query = $this->modelsManager->createBuilder()
    ->columns('u.id, u.username, u.nickname, u.phone, u.parent_id, p.username AS parent_username, p.nickname AS parent_nickname, u.created_at, MAX(s.created_at) AS logged_at, u.active')
    ->addFrom('Bet\Models\Users', 'u')
    ->leftJoin('Bet\Models\SuccessLogins', 'u.id = s.user_id', 's')
    ->leftJoin('Bet\Models\Users', 'u.parent_id = p.id', 'p')
    ->where('u.role_id = "member"')
    ->andWhere('p.role_id = "admin"');

$seachVal = $this->request->get('search')['value'];
if (!empty($seachVal)) {
    $query = $query->orWhere('u.nickname LIKE :s:', [
        's' => '%' . $seachVal . '%'
    ]);
}

$query = $query->groupBy('u.id')
    ->getQuery()
    ->getSql();
```
It received an error:
```log
[04-Aug-2019 12:53:40 Asia/Ho_Chi_Minh] SQLSTATE[HY093]: Invalid parameter number: no parameters were bound
#0 [internal function]: PDOStatement->execute()
#1 [internal function]: Phalcon\Db\Adapter\Pdo->executePrepared(Object(PDOStatement), Array, NULL)
#2 ..\vendor\ozdemir\datatables\src\DB\PhalconAdapter.php(54): Phalcon\Db\Adapter\Pdo->query('Select count(*)...', Array)
#3 ..\vendor\ozdemir\datatables\src\Datatables.php(244): Ozdemir\Datatables\DB\PhalconAdapter->count(Object(Ozdemir\Datatables\Query))
#4 ..\vendor\ozdemir\datatables\src\Datatables.php(196): Ozdemir\Datatables\Datatables->setResponseData()
#5 ..\app\modules\backend\controllers\DlCap1Controller.php(95): Ozdemir\Datatables\Datatables->generate()
#6 [internal function]: Bet\Modules\Backend\Controllers\DlCap1Controller->indexAction()
#7 [internal function]: Phalcon\Dispatcher->callActionMethod(Object(Bet\Modules\Backend\Controllers\DlCap1Controller), 'indexAction', Array)
#8 [internal function]: Phalcon\Dispatcher->dispatch()
#9 ..\app\bootstrap_web.php(58): Phalcon\Mvc\Application->handle()
#10 ..\public\index.php(7): require('..\\ap...')
#11 {main}
```

I also tried `filter()` but it didn't work, because it was imploded by `AND`:
```php
$seachVal = $this->request->get('search')['value'];
$dt->filter('username', function() use ($seachVal){
    if(!empty($seachVal)) return 'nickname LIKE '.$this->escape('%'.$seachVal.'%');
    return '';
});
```