### PR TITLE
Add Doc VSCode Compatibility

### DIFF
--- a/src/Datatables.php
+++ b/src/Datatables.php
@@ -170,7 +170,7 @@ class Datatables
     }
 
     /**
-     * @param string $query
+     * @param string|\CodeIgniter\Database\BaseBuilder $query
      * @return Datatables
      */
     public function query($query): Datatables


### PR DESCRIPTION
remove warning message from VScode when using CI4Adapter

## Reason
When I use VSCode and apply the library for Codeigniter 4, there's a warning message in VSCode like the screenshot below. This message doesn't cause errors, but it's quite annoying for some people because of the warning message.

![Screenshot_20240415_101842](https://github.com/n1crack/datatables/assets/87152520/1a6a0625-3351-49bf-9801-2892eaf393f3)

## Additional
I only added for Codeigniter4Adapter, but I haven't tried how other adapters might also trigger warning messages.