### PR TITLE
Update GitHub Actions to use latest Ubuntu and PHP versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,18 +6,21 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, '8.0', 8.1]
+        php: [7.1, 7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Switch Ubuntu 20 to Ubuntu latest (v20 doesn't exist anymore), add all new stable php versions and update checkout task to the current version.